### PR TITLE
removed freshness test on payments

### DIFF
--- a/models/staging/stripe/src_stripe.yml
+++ b/models/staging/stripe/src_stripe.yml
@@ -7,10 +7,6 @@ sources:
     tables:
       - name: payment
         description: Raw payments data.
-        loaded_at_field: created
-        freshness:
-          warn_after: {count: 12, period: hour}
-          error_after: {count: 24, period: hour}
         columns:
           - name: id
             description: Primary key for payments.


### PR DESCRIPTION
Removing freshness test on payments as the column is not of timestamp value.